### PR TITLE
Release 2.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,10 +79,10 @@ session_set_save_handler($handler, true);
 ```php
 <?php
 $sessionConfig = (new \ByJG\Session\SessionConfig('your.domain.com'))
-    ->withSecret('your super secret key');
+    ->withSecret('your super secret key')
+    ->replaceSessionHandler();
 
 $handler = new \ByJG\Session\JwtSession($sessionConfig);
-$handler->replaceSessionHandler(true);
 ```
 
 # Specify cookie domain 
@@ -91,10 +91,10 @@ $handler->replaceSessionHandler(true);
 <?php
 $sessionConfig = (new \ByJG\Session\SessionConfig('your.domain.com'))
     ->withSecret('your super secret key')
-    ->withCookie('.mydomain.com', '/');
+    ->withCookie('.mydomain.com', '/')
+    ->replaceSessionHandler();
 
 $handler = new \ByJG\Session\JwtSession($sessionConfig);
-$handler->replaceSessionHandler(true);
 ```
 
 # Uses RSA Private/Public Keys
@@ -143,10 +143,11 @@ owIDAQAB
 -----END PUBLIC KEY-----
 PUBLIC;
 
-$this->sessionConfig = (new \ByJG\Session\SessionConfig('example.com'))
-    ->withRsaSecret($secret, $public);
+$sessionConfig = (new \ByJG\Session\SessionConfig('example.com'))
+    ->withRsaSecret($secret, $public)
+    ->replaceSessionHandler();
 
-$handler->replaceSessionHandler(true);
+$handler = new \ByJG\Session\JwtSession($sessionConfig);
 ```
 
 If you want to know more details about how to create RSA Public/Private Keys access:

--- a/README.md
+++ b/README.md
@@ -13,7 +13,10 @@ Before the session_start() use the command:
 
 ```php
 <?php
-$handler = new \ByJG\Session\JwtSession('your.domain.com', 'your super secret key');
+$sessionConfig = (new \ByJG\Session\SessionConfig('your.domain.com'))
+    ->withSecret('your super secret key');
+
+$handler = new \ByJG\Session\JwtSession($sessionConfig);
 session_set_save_handler($handler, true);
 ```
 
@@ -34,7 +37,7 @@ Just to use.
 You can read more in this Codementor's article: 
 [Using JSON Web Token (JWT) as a PHP Session](https://www.codementor.io/byjg/using-json-web-token-jwt-as-a-php-session-axeuqbg1m)
 
-## Security Information
+# Security Information
 
 The JWT Token cannot be changed, but it can be read. 
 This implementation save the JWT into a client cookie.  
@@ -43,45 +46,112 @@ Because of this _**do not** store in the JWT Token sensible data like passwords_
 # Install
 
 ```
-composer require "byjg/jwt-session=1.0.*"
+composer require "byjg/jwt-session=2.0.*"
 ```
 
-# Customizations
  
-## Setting the validity of JWT Token
+# Setting the validity of JWT Token
 
 ```php
 <?php
-// Setting to 50 minutes
-$handler = new \ByJG\Session\JwtSession('your.domain.com', 'your super secret key', 50);
+$sessionConfig = (new \ByJG\Session\SessionConfig('your.domain.com'))
+    ->withSecret('your super secret key')
+    ->withTimeoutMinutes(50);
+
+$handler = new \ByJG\Session\JwtSession($sessionConfig);
 session_set_save_handler($handler, true);
 ```
 
-## Setting the different Session Contexts
+# Setting the different Session Contexts
 
 ```php
 <?php
-$handler = new \ByJG\Session\JwtSession('your.domain.com', 'your super secret key', 20, 'MYCONTEXT');
+$sessionConfig = (new \ByJG\Session\SessionConfig('your.domain.com'))
+    ->withSessionContext('MYCONTEXT');
+
+$handler = new \ByJG\Session\JwtSession($sessionConfig);
 session_set_save_handler($handler, true);
 ```
 
-## Create the handler and replace the session handler
+# Create the handler and replace the session handler
 
 ```php
 <?php
-$handler = new \ByJG\Session\JwtSession('your.domain.com', 'your super secret key');
+$sessionConfig = (new \ByJG\Session\SessionConfig('your.domain.com'))
+    ->withSecret('your super secret key');
+
+$handler = new \ByJG\Session\JwtSession($sessionConfig);
 $handler->replaceSessionHandler(true);
 ```
 
-## Create the handler and replace the session handler, specifying cookie domain valid for all subdomains of mydomain.com
+# Specify cookie domain 
 
 ```php
 <?php
-$handler = new \ByJG\Session\JwtSession('your.domain.com', 'your super secret key', null, null, '.mydomain.com');
+$sessionConfig = (new \ByJG\Session\SessionConfig('your.domain.com'))
+    ->withCookie('.mydomain.com', '/');
+
+$handler = new \ByJG\Session\JwtSession($sessionConfig);
 $handler->replaceSessionHandler(true);
 ```
 
-## How it works
+# Uses RSA Private/Public Keys
+
+```php
+<?php
+        $secret = <<<PRIVATE
+-----BEGIN RSA PRIVATE KEY-----
+MIIEpQIBAAKCAQEA5PMdWRa+rUJmg6QMNAPIXa+BJVN7W0vxPN3WTK/OIv5gxgmj
+2inHGGc6f90TW/to948LnqGtcD3CD9KsI55MubafwBYjcds1o9opZ0vYwwdIV80c
+OVZX1IUZFTbnyyKcXeFmKt49A52haCiy4iNxcRK38tOCApjZySx/NzMDeaXuWe+1
+nd3pbgYa/I8MkECa5EyabhZJPJo9fGoSZIklNnyq4TfAUSwl+KN/zjj3CXad1oDT
+7XDDgMJDUu/Vxs7h3CQI9zILSYcL9zwttbLnJW1WcLlAAIaAfABtSZboznsStMnY
+to01wVknXKyERFs7FLHYqKQANIvRhFTptsehowIDAQABAoIBAEkJkaQ5EE0fcKqw
+K8BwMHxKn81zi1e9q1C6iEHgl8csFV03+BCB4WTUkaH2udVPJ9ZJyPArLbQvz3fS
+wl1+g4V/UAksRtRslPkXgLvWQ2k8KoTwBv/3nn9Kkozk/h8chHuii0BDs30yzSn4
+SdDAc9EZopsRhFklv9xgmJjYalRk02OLck73G+d6MpDqX56o2UA/lf6i9MV19KWP
+HYip7CAN+i6k8gA0KPHwr76ehgQ6YHtSntkWS8RfVI8fLUB1UlT3HmLgUBNXMWkQ
+ZZbvXtNOt6NtW/WIAHEYeE9jmFgrpW5jKJSLn5iGVPFZwJIZXRPyELEs9NHWkS6e
+GmdzxnECgYEA8+m05B/tmeZOuMrPVJV9g+aBDcuxmW+sdLRch+ccSmx4ZNQOLVoU
+klYgTZq/a1O4ENq0h2WgccNlRHdcH4sXMBvLalA/tFhZMUuA/KXWyZ1F0hBnjHVF
+cj1alHCqh+9qJDGdn4mxSmrp8p0rfeWgBwlFtJEJmjjDWDCtVY+JZcsCgYEA8EuV
+WF/ilgDjgC4jMCYNuO0oFGBbtNP17PuU3kh8W+joqK/nufZ3NLy1WrDIpqa9YPex
+328Nnjljf5GJWSdMchAp82waLzl7FaaBTY0iyFAK4J0jfC/fVLx82+wpM3utDnh8
+9x5iIboO5U7uEJ7k8X2p64GoprlKJSRmGAJ7eIkCgYEAw5IsXI3NMY0cqcbUHvoO
+PehgqfMdX+3O1XSYjM+eO35lulLdWzfTLtKn7BGcUi46dCkofzfZQd5uIEukLhaU
+bRqcK45UxgHg4kmsDufaJKZaCWjl3hVZrZPMQSFlWsF41bSCshzxbr3y/3lOGhA4
+E+w3W+S/Uk0ZNGkzUltYy6kCgYEA0gRNeBr9z7rhG4O3j3qC3dCxCfYZ0Na8hy5v
+M0PJJQ9QYTa04iyOjVItcyE1jaoHtLtoA+9syJBB7RoHIBufzcVg1Pbzf7jOYeLP
++jbTYp3Kk/vjKsQwfj/rJM+oRu3eF9qo5dbxT6btI++zVGV7lbEOFN6Sx30EV6gT
+bwKkZXkCgYEAnEtN43xL8bRFybMc1ZJErjc0VocnoQxCHm7LuAtLOEUw6CwwFj9Q
+GOl+GViVuDHUNQvURLn+6gg4tAemYlob912xIPaU44+lZzTMHBOJBGMJKi8WogKi
+V5+cz9l31uuAgNfjL63jZPaAzKs8Zx6R3O5RuezympwijCIGWILbO2Q=
+-----END RSA PRIVATE KEY-----
+PRIVATE;
+
+        $public = <<<PUBLIC
+-----BEGIN PUBLIC KEY-----
+MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA5PMdWRa+rUJmg6QMNAPI
+Xa+BJVN7W0vxPN3WTK/OIv5gxgmj2inHGGc6f90TW/to948LnqGtcD3CD9KsI55M
+ubafwBYjcds1o9opZ0vYwwdIV80cOVZX1IUZFTbnyyKcXeFmKt49A52haCiy4iNx
+cRK38tOCApjZySx/NzMDeaXuWe+1nd3pbgYa/I8MkECa5EyabhZJPJo9fGoSZIkl
+Nnyq4TfAUSwl+KN/zjj3CXad1oDT7XDDgMJDUu/Vxs7h3CQI9zILSYcL9zwttbLn
+JW1WcLlAAIaAfABtSZboznsStMnYto01wVknXKyERFs7FLHYqKQANIvRhFTptseh
+owIDAQAB
+-----END PUBLIC KEY-----
+PUBLIC;
+
+$this->sessionConfig = (new \ByJG\Session\SessionConfig('example.com'))
+    ->withRsaSecret($secret, $public);
+
+$handler->replaceSessionHandler(true);
+```
+
+If you want to know more details about how to create RSA Public/Private Keys access:
+https://github.com/byjg/jwt-wrapper 
+
+
+# How it works
 
 We store a cookie named AUTH_BEARER_<context name> with the session name. The PHPSESSID cookie is still created because
 PHP create it by default but we do not use it;

--- a/README.md
+++ b/README.md
@@ -160,3 +160,5 @@ We store a cookie named AUTH_BEARER_<context name> with the session name. The PH
 PHP create it by default but we do not use it;
 
 
+----
+[Open source ByJG](http://opensource.byjg.com)

--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ session_set_save_handler($handler, true);
 ```php
 <?php
 $sessionConfig = (new \ByJG\Session\SessionConfig('your.domain.com'))
+    ->withSecret('your super secret key')
     ->withSessionContext('MYCONTEXT');
 
 $handler = new \ByJG\Session\JwtSession($sessionConfig);
@@ -89,6 +90,7 @@ $handler->replaceSessionHandler(true);
 ```php
 <?php
 $sessionConfig = (new \ByJG\Session\SessionConfig('your.domain.com'))
+    ->withSecret('your super secret key')
     ->withCookie('.mydomain.com', '/');
 
 $handler = new \ByJG\Session\JwtSession($sessionConfig);

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ composer require "byjg/jwt-session=2.0.*"
 <?php
 $sessionConfig = (new \ByJG\Session\SessionConfig('your.domain.com'))
     ->withSecret('your super secret key')
-    ->withTimeoutMinutes(50);
+    ->withTimeoutMinutes(60);   // You can use withTimeoutHours(1)
 
 $handler = new \ByJG\Session\JwtSession($sessionConfig);
 session_set_save_handler($handler, true);

--- a/_config.yml
+++ b/_config.yml
@@ -41,13 +41,26 @@ social:
     hash: opensourcebyjg
     account: 
   facebook:
-    enabled: false
+    enabled: true
+    url: https://opensource.byjg.com/
     profileUrl:
+
+author:
+  twitter: byjg
+
+twitter:
+  card: summary
+  username: byjg
+
+logo: https://opensource.byjg.com/images/logo_byjg.png
 
 analytics:
   google: UA-130014324-1
 
+plugins:
+  - jekyll-seo-tag
+
 # Build settings
 markdown: kramdown
-remote_theme: allejo/jekyll-docs-theme
+remote_theme: byjg/jekyll-docs-theme
 

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     "prefer-stable": true,
     "require": {
         "php": ">=5.6.0",
-        "byjg/jwt-wrapper": "1.0.*"
+        "byjg/jwt-wrapper": "2.0.*"
     },
     "require-dev": {
         "phpunit/phpunit": ">=5.7"

--- a/src/JwtSession.php
+++ b/src/JwtSession.php
@@ -18,9 +18,13 @@ class JwtSession implements SessionHandlerInterface
      * JwtSession constructor.
      *
      * @param $sessionConfig
+     * @throws JwtSessionException
      */
     public function __construct($sessionConfig)
     {
+        if (!($sessionConfig instanceof SessionConfig)) {
+            throw new JwtSessionException('Required SessionConfig instance');
+        }
         $this->sessionConfig = $sessionConfig;
     }
 
@@ -33,6 +37,8 @@ class JwtSession implements SessionHandlerInterface
         if (session_status() != PHP_SESSION_NONE) {
             throw new JwtSessionException('Session already started!');
         }
+
+        ini_set("session.use_cookies", 0);
 
         session_set_save_handler($this, true);
 
@@ -141,6 +147,10 @@ class JwtSession implements SessionHandlerInterface
                     $this->sessionConfig->getPublicKey()
                 );
                 $data = $jwt->extractData($_COOKIE[self::COOKIE_PREFIX . $this->sessionConfig->getSessionContext()]);
+
+                if (empty($data->data)) {
+                    return '';
+                }
 
                 return $data->data;
             }

--- a/src/JwtSession.php
+++ b/src/JwtSession.php
@@ -22,6 +22,8 @@ class JwtSession implements SessionHandlerInterface
      */
     public function __construct($sessionConfig)
     {
+        ini_set("session.use_cookies", 0);
+
         if (!($sessionConfig instanceof SessionConfig)) {
             throw new JwtSessionException('Required SessionConfig instance');
         }
@@ -37,8 +39,6 @@ class JwtSession implements SessionHandlerInterface
         if (session_status() != PHP_SESSION_NONE) {
             throw new JwtSessionException('Session already started!');
         }
-
-        ini_set("session.use_cookies", 0);
 
         session_set_save_handler($this, true);
 

--- a/src/JwtSession.php
+++ b/src/JwtSession.php
@@ -148,8 +148,7 @@ class JwtSession implements SessionHandlerInterface
             if (isset($_COOKIE[self::COOKIE_PREFIX . $this->sessionConfig->getSessionContext()])) {
                 $jwt = new JwtWrapper(
                     $this->sessionConfig->getServerName(),
-                    $this->sessionConfig->getSecretKey(),
-                    $this->sessionConfig->getPublicKey()
+                    $this->sessionConfig->getKey()
                 );
                 $data = $jwt->extractData($_COOKIE[self::COOKIE_PREFIX . $this->sessionConfig->getSessionContext()]);
 
@@ -181,14 +180,14 @@ class JwtSession implements SessionHandlerInterface
      * The return value (usually TRUE on success, FALSE on failure).
      * Note this value is returned internally to PHP for processing.
      * </p>
+     * @throws \ByJG\Util\JwtWrapperException
      * @since 5.4.0
      */
     public function write($session_id, $session_data)
     {
         $jwt = new JwtWrapper(
             $this->sessionConfig->getServerName(),
-            $this->sessionConfig->getSecretKey(),
-            $this->sessionConfig->getPublicKey()
+            $this->sessionConfig->getKey()
         );
         $data = $jwt->createJwtData($session_data, $this->sessionConfig->getTimeoutMinutes() * 60);
         $token = $jwt->generateToken($data);

--- a/src/JwtSession.php
+++ b/src/JwtSession.php
@@ -27,14 +27,19 @@ class JwtSession implements SessionHandlerInterface
         if (!($sessionConfig instanceof SessionConfig)) {
             throw new JwtSessionException('Required SessionConfig instance');
         }
+
         $this->sessionConfig = $sessionConfig;
+
+        if ($this->sessionConfig->isReplaceSession()) {
+            $this->replaceSessionHandler();
+        }
     }
 
     /**
      * @param bool $startSession
      * @throws JwtSessionException
      */
-    public function replaceSessionHandler($startSession = true)
+    protected function replaceSessionHandler()
     {
         if (session_status() != PHP_SESSION_NONE) {
             throw new JwtSessionException('Session already started!');
@@ -42,7 +47,7 @@ class JwtSession implements SessionHandlerInterface
 
         session_set_save_handler($this, true);
 
-        if ($startSession) {
+        if ($this->sessionConfig->isStartSession()) {
             ob_start();
             session_start();
         }

--- a/src/SessionConfig.php
+++ b/src/SessionConfig.php
@@ -12,6 +12,7 @@ class SessionConfig
     protected $cookiePath = '/';
     protected $secretKey = null;
     protected $publicKey = null;
+    protected $replaceSessionHandler = null;
 
     /**
      * SessionConfig constructor.
@@ -52,6 +53,11 @@ class SessionConfig
     public function withRsaSecret($private, $public) {
         $this->secretKey = $private;
         $this->publicKey = $public;
+        return $this;
+    }
+
+    public function replaceSessionHandler($startSession = true) {
+        $this->replaceSessionHandler = $startSession;
         return $this;
     }
 
@@ -109,5 +115,13 @@ class SessionConfig
     public function getPublicKey()
     {
         return $this->publicKey;
+    }
+
+    public function isReplaceSession() {
+        return $this->replaceSessionHandler !== null;
+    }
+
+    public function isStartSession() {
+        return $this->replaceSessionHandler === true;
     }
 }

--- a/src/SessionConfig.php
+++ b/src/SessionConfig.php
@@ -2,6 +2,10 @@
 
 namespace ByJG\Session;
 
+use ByJG\Util\JwtKeyInterface;
+use ByJG\Util\JwtKeySecret;
+use ByJG\Util\JwtRsaKey;
+
 class SessionConfig
 {
     protected $serverName;
@@ -10,8 +14,7 @@ class SessionConfig
     protected $timeoutMinutes = 20;
     protected $cookieDomain = null;
     protected $cookiePath = '/';
-    protected $secretKey = null;
-    protected $publicKey = null;
+    protected $jwtKey = null;
     protected $replaceSessionHandler = null;
 
     /**
@@ -45,14 +48,12 @@ class SessionConfig
     }
 
     public function withSecret($secret) {
-        $this->secretKey = $secret;
-        $this->publicKey = null;
+        $this->jwtKey = new JwtKeySecret($secret);
         return $this;
     }
     
     public function withRsaSecret($private, $public) {
-        $this->secretKey = $private;
-        $this->publicKey = $public;
+        $this->jwtKey = new JwtRsaKey($private, $public);
         return $this;
     }
 
@@ -102,19 +103,11 @@ class SessionConfig
     }
 
     /**
-     * @return null
+     * @return JwtKeyInterface
      */
-    public function getSecretKey()
+    public function getKey()
     {
-        return $this->secretKey;
-    }
-
-    /**
-     * @return null
-     */
-    public function getPublicKey()
-    {
-        return $this->publicKey;
+        return $this->jwtKey;
     }
 
     public function isReplaceSession() {

--- a/src/SessionConfig.php
+++ b/src/SessionConfig.php
@@ -1,0 +1,108 @@
+<?php
+
+namespace ByJG\Session;
+
+class SessionConfig
+{
+    protected $serverName;
+
+    protected $sessionContext = 'default';
+    protected $timeoutMinutes = 20;
+    protected $cookieDomain = null;
+    protected $cookiePath = '/';
+    protected $secretKey = null;
+    protected $publicKey = null;
+
+    /**
+     * SessionConfig constructor.
+     * @param $serverName
+     */
+    public function __construct($serverName)
+    {
+        $this->serverName = $serverName;
+    }
+
+    public function withSessionContext($context) {
+        $this->sessionContext = $context;
+        return $this;
+    }
+
+    public function withTimeoutMinutes($timeout) {
+        $this->timeoutMinutes = $timeout;
+        return $this;
+    }
+
+    public function withCookie($domain, $path = "/") {
+        $this->cookieDomain = $domain;
+        $this->cookiePath = $path;
+        return $this;
+    }
+
+    public function withSecret($secret) {
+        $this->secretKey = $secret;
+        $this->publicKey = null;
+        return $this;
+    }
+    
+    public function withRsaSecret($private, $public) {
+        $this->secretKey = $private;
+        $this->publicKey = $public;
+        return $this;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getServerName()
+    {
+        return $this->serverName;
+    }
+
+    /**
+     * @return string
+     */
+    public function getSessionContext()
+    {
+        return $this->sessionContext;
+    }
+
+    /**
+     * @return int
+     */
+    public function getTimeoutMinutes()
+    {
+        return $this->timeoutMinutes;
+    }
+
+    /**
+     * @return null
+     */
+    public function getCookieDomain()
+    {
+        return $this->cookieDomain;
+    }
+
+    /**
+     * @return string
+     */
+    public function getCookiePath()
+    {
+        return $this->cookiePath;
+    }
+
+    /**
+     * @return null
+     */
+    public function getSecretKey()
+    {
+        return $this->secretKey;
+    }
+
+    /**
+     * @return null
+     */
+    public function getPublicKey()
+    {
+        return $this->publicKey;
+    }
+}

--- a/src/SessionConfig.php
+++ b/src/SessionConfig.php
@@ -32,6 +32,11 @@ class SessionConfig
         return $this;
     }
 
+    public function withTimeoutHours($timeout) {
+        $this->timeoutMinutes = $timeout * 60;
+        return $this;
+    }
+
     public function withCookie($domain, $path = "/") {
         $this->cookieDomain = $domain;
         $this->cookiePath = $path;

--- a/tests/JwtSessionRsaTest.php
+++ b/tests/JwtSessionRsaTest.php
@@ -1,0 +1,58 @@
+<?php
+
+use ByJG\Session\JwtSession;
+
+require_once __DIR__ . "/JwtSessionTest.php";
+
+class JwtSessionRsaTest extends JwtSessionTest
+{
+    protected function setUp()
+    {
+        $secret = <<<PRIVATE
+-----BEGIN RSA PRIVATE KEY-----
+MIIEpQIBAAKCAQEA5PMdWRa+rUJmg6QMNAPIXa+BJVN7W0vxPN3WTK/OIv5gxgmj
+2inHGGc6f90TW/to948LnqGtcD3CD9KsI55MubafwBYjcds1o9opZ0vYwwdIV80c
+OVZX1IUZFTbnyyKcXeFmKt49A52haCiy4iNxcRK38tOCApjZySx/NzMDeaXuWe+1
+nd3pbgYa/I8MkECa5EyabhZJPJo9fGoSZIklNnyq4TfAUSwl+KN/zjj3CXad1oDT
+7XDDgMJDUu/Vxs7h3CQI9zILSYcL9zwttbLnJW1WcLlAAIaAfABtSZboznsStMnY
+to01wVknXKyERFs7FLHYqKQANIvRhFTptsehowIDAQABAoIBAEkJkaQ5EE0fcKqw
+K8BwMHxKn81zi1e9q1C6iEHgl8csFV03+BCB4WTUkaH2udVPJ9ZJyPArLbQvz3fS
+wl1+g4V/UAksRtRslPkXgLvWQ2k8KoTwBv/3nn9Kkozk/h8chHuii0BDs30yzSn4
+SdDAc9EZopsRhFklv9xgmJjYalRk02OLck73G+d6MpDqX56o2UA/lf6i9MV19KWP
+HYip7CAN+i6k8gA0KPHwr76ehgQ6YHtSntkWS8RfVI8fLUB1UlT3HmLgUBNXMWkQ
+ZZbvXtNOt6NtW/WIAHEYeE9jmFgrpW5jKJSLn5iGVPFZwJIZXRPyELEs9NHWkS6e
+GmdzxnECgYEA8+m05B/tmeZOuMrPVJV9g+aBDcuxmW+sdLRch+ccSmx4ZNQOLVoU
+klYgTZq/a1O4ENq0h2WgccNlRHdcH4sXMBvLalA/tFhZMUuA/KXWyZ1F0hBnjHVF
+cj1alHCqh+9qJDGdn4mxSmrp8p0rfeWgBwlFtJEJmjjDWDCtVY+JZcsCgYEA8EuV
+WF/ilgDjgC4jMCYNuO0oFGBbtNP17PuU3kh8W+joqK/nufZ3NLy1WrDIpqa9YPex
+328Nnjljf5GJWSdMchAp82waLzl7FaaBTY0iyFAK4J0jfC/fVLx82+wpM3utDnh8
+9x5iIboO5U7uEJ7k8X2p64GoprlKJSRmGAJ7eIkCgYEAw5IsXI3NMY0cqcbUHvoO
+PehgqfMdX+3O1XSYjM+eO35lulLdWzfTLtKn7BGcUi46dCkofzfZQd5uIEukLhaU
+bRqcK45UxgHg4kmsDufaJKZaCWjl3hVZrZPMQSFlWsF41bSCshzxbr3y/3lOGhA4
+E+w3W+S/Uk0ZNGkzUltYy6kCgYEA0gRNeBr9z7rhG4O3j3qC3dCxCfYZ0Na8hy5v
+M0PJJQ9QYTa04iyOjVItcyE1jaoHtLtoA+9syJBB7RoHIBufzcVg1Pbzf7jOYeLP
++jbTYp3Kk/vjKsQwfj/rJM+oRu3eF9qo5dbxT6btI++zVGV7lbEOFN6Sx30EV6gT
+bwKkZXkCgYEAnEtN43xL8bRFybMc1ZJErjc0VocnoQxCHm7LuAtLOEUw6CwwFj9Q
+GOl+GViVuDHUNQvURLn+6gg4tAemYlob912xIPaU44+lZzTMHBOJBGMJKi8WogKi
+V5+cz9l31uuAgNfjL63jZPaAzKs8Zx6R3O5RuezympwijCIGWILbO2Q=
+-----END RSA PRIVATE KEY-----
+PRIVATE;
+
+        $public = <<<PUBLIC
+-----BEGIN PUBLIC KEY-----
+MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA5PMdWRa+rUJmg6QMNAPI
+Xa+BJVN7W0vxPN3WTK/OIv5gxgmj2inHGGc6f90TW/to948LnqGtcD3CD9KsI55M
+ubafwBYjcds1o9opZ0vYwwdIV80cOVZX1IUZFTbnyyKcXeFmKt49A52haCiy4iNx
+cRK38tOCApjZySx/NzMDeaXuWe+1nd3pbgYa/I8MkECa5EyabhZJPJo9fGoSZIkl
+Nnyq4TfAUSwl+KN/zjj3CXad1oDT7XDDgMJDUu/Vxs7h3CQI9zILSYcL9zwttbLn
+JW1WcLlAAIaAfABtSZboznsStMnYto01wVknXKyERFs7FLHYqKQANIvRhFTptseh
+owIDAQAB
+-----END PUBLIC KEY-----
+PUBLIC;
+
+        $this->sessionConfig = (new \ByJG\Session\SessionConfig('example.com'))
+            ->withRsaSecret($secret, $public);
+
+        $this->object = new JwtSession($this->sessionConfig);
+    }
+}

--- a/tests/JwtSessionTest.php
+++ b/tests/JwtSessionTest.php
@@ -12,11 +12,19 @@ class JwtSessionTest extends \PHPUnit\Framework\TestCase
      */
     protected $object;
 
+    /**
+     * @var \ByJG\Session\SessionConfig
+     */
+    protected $sessionConfig;
+
     const SESSION_ID = "sessionid";
 
     protected function setUp()
     {
-        $this->object = new JwtSession("example.com", "secretKey");
+        $this->sessionConfig = (new \ByJG\Session\SessionConfig('example.com'))
+            ->withSecret('secretKey');
+
+        $this->object = new JwtSession($this->sessionConfig);
     }
 
     protected function tearDown()

--- a/webtest/destroy.php
+++ b/webtest/destroy.php
@@ -3,9 +3,10 @@
 require_once __DIR__ . "/../vendor/autoload.php";
 
 $sessionConfig = (new \ByJG\Session\SessionConfig('api.com.br'))
-    ->withSecret('1234567890');
+    ->withSecret('1234567890')
+    ->replaceSessionHandler();
+
 $handler = new \ByJG\Session\JwtSession($sessionConfig);
-$handler->replaceSessionHandler(true);
 
 session_destroy();
 ?>

--- a/webtest/destroy.php
+++ b/webtest/destroy.php
@@ -2,7 +2,9 @@
 
 require_once __DIR__ . "/../vendor/autoload.php";
 
-$handler = new \ByJG\Session\JwtSession('api.com.br', '1234567890');
+$sessionConfig = (new \ByJG\Session\SessionConfig('api.com.br'))
+    ->withSecret('1234567890');
+$handler = new \ByJG\Session\JwtSession($sessionConfig);
 $handler->replaceSessionHandler(true);
 
 session_destroy();

--- a/webtest/index.php
+++ b/webtest/index.php
@@ -3,7 +3,9 @@
 require_once __DIR__ . "/../vendor/autoload.php";
 
 if (!isset($_REQUEST['turnoff'])) {   // Just for turnoff the session
-    $handler = new \ByJG\Session\JwtSession('api.com.br', '1234567890');
+    $sessionConfig = (new \ByJG\Session\SessionConfig('api.com.br'))
+        ->withSecret('1234567890');
+    $handler = new \ByJG\Session\JwtSession($sessionConfig);
     $handler->replaceSessionHandler(true);
 } else {
     echo "<H1>JWT Session is disabled</H1>";

--- a/webtest/index.php
+++ b/webtest/index.php
@@ -4,9 +4,9 @@ require_once __DIR__ . "/../vendor/autoload.php";
 
 if (!isset($_REQUEST['turnoff'])) {   // Just for turnoff the session
     $sessionConfig = (new \ByJG\Session\SessionConfig('api.com.br'))
-        ->withSecret('1234567890');
+        ->withSecret('1234567890')
+        ->replaceSessionHandler();
     $handler = new \ByJG\Session\JwtSession($sessionConfig);
-    $handler->replaceSessionHandler(true);
 } else {
     echo "<H1>JWT Session is disabled</H1>";
     session_start();

--- a/webtest/setsession.php
+++ b/webtest/setsession.php
@@ -2,7 +2,9 @@
 
 require_once __DIR__ . "/../vendor/autoload.php";
 
-$handler = new \ByJG\Session\JwtSession('api.com.br', '1234567890');
+$sessionConfig = (new \ByJG\Session\SessionConfig('api.com.br'))
+    ->withSecret('1234567890');
+$handler = new \ByJG\Session\JwtSession($sessionConfig);
 $handler->replaceSessionHandler(true);
 
 $count = intval($_SESSION['count']) + 1;

--- a/webtest/setsession.php
+++ b/webtest/setsession.php
@@ -3,9 +3,9 @@
 require_once __DIR__ . "/../vendor/autoload.php";
 
 $sessionConfig = (new \ByJG\Session\SessionConfig('api.com.br'))
-    ->withSecret('1234567890');
+    ->withSecret('1234567890')
+    ->replaceSessionHandler();
 $handler = new \ByJG\Session\JwtSession($sessionConfig);
-$handler->replaceSessionHandler(true);
 
 $count = intval($_SESSION['count']) + 1;
 

--- a/webtest/unsetsession.php
+++ b/webtest/unsetsession.php
@@ -2,7 +2,9 @@
 
 require_once __DIR__ . "/../vendor/autoload.php";
 
-$handler = new \ByJG\Session\JwtSession('api.com.br', '1234567890');
+$sessionConfig = (new \ByJG\Session\SessionConfig('api.com.br'))
+    ->withSecret('1234567890');
+$handler = new \ByJG\Session\JwtSession($sessionConfig);
 $handler->replaceSessionHandler(true);
 
 $count = intval($_SESSION['count']);

--- a/webtest/unsetsession.php
+++ b/webtest/unsetsession.php
@@ -3,9 +3,10 @@
 require_once __DIR__ . "/../vendor/autoload.php";
 
 $sessionConfig = (new \ByJG\Session\SessionConfig('api.com.br'))
-    ->withSecret('1234567890');
+    ->withSecret('1234567890')
+    ->replaceSessionHandler();
+
 $handler = new \ByJG\Session\JwtSession($sessionConfig);
-$handler->replaceSessionHandler(true);
 
 $count = intval($_SESSION['count']);
 


### PR DESCRIPTION
Important changes that break compatibility with previous versions:

- Upgrade Jwt-Wrapper component (https://github.com/byjg/jwt-wrapper/pull/2)
- Use SessionConfig class instead a lot or arguments
- Removing PHPSESSID based on issue #10
- Moving method `replaceSessionHandler()` to `SessionConfig`

**Examples:**

*before*

```php
<?php
$handler = new \ByJG\Session\JwtSession('your.domain.com', 'your super secret key', null, null, '.mydomain.com');
 $handler->replaceSessionHandler(true);
```

*now*

```php
<?php
$sessionConfig = (new \ByJG\Session\SessionConfig('your.domain.com'))
     ->withSecret('your super secret key')
     ->withCookie('.mydomain.com', '/')
     ->replaceSessionHandler();
 
 $handler = new \ByJG\Session\JwtSession($sessionConfig);
```
