### PR TITLE
JWT Session 6.0 - Major Version Update

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -12,7 +12,9 @@ on:
 jobs:
   Build:
     runs-on: 'ubuntu-latest'
-    container: 'byjg/php:${{ matrix.php-version }}-cli'
+    container:
+      image: 'byjg/php:${{ matrix.php-version }}-cli'
+      options: --user root --privileged
     strategy:
       matrix:
         php-version:
@@ -22,7 +24,7 @@ jobs:
           - "8.1"
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - run: composer install
       - run: ./vendor/bin/phpunit
 

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -16,9 +16,10 @@ jobs:
     strategy:
       matrix:
         php-version:
+          - "8.4"
+          - "8.3"
           - "8.2"
           - "8.1"
-          - "8.0"
 
     steps:
       - uses: actions/checkout@v4
@@ -32,5 +33,6 @@ jobs:
     with:
       folder: php
       project: ${{ github.event.repository.name }}
-    secrets: inherit
+    secrets:
+      DOC_TOKEN: ${{ secrets.DOC_TOKEN }}
 

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@
 composer.lock
 vendor
 /.phpunit.result.cache
+phpunit.coverage.xml
+phpunit.report.xml
+*.bak

--- a/composer.json
+++ b/composer.json
@@ -9,11 +9,16 @@
   "minimum-stability": "dev",
   "prefer-stable": true,
   "require": {
-    "php": ">=8.0",
-    "byjg/jwt-wrapper": "4.9.*"
+    "php": ">=8.1 <8.5",
+    "byjg/jwt-wrapper": "^6.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "5.7.*|7.4.*|^9.6"
+    "phpunit/phpunit": "^10|^11",
+    "vimeo/psalm": "^5.9|^6.12"
+  },
+  "scripts": {
+    "test": "vendor/bin/phpunit",
+    "psalm": "vendor/bin/psalm"
   },
   "license": "MIT"
 }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -6,14 +6,21 @@ and open the template in the editor.
 -->
 
 <!-- see http://www.phpunit.de/wiki/Documentation -->
-<phpunit bootstrap="./vendor/autoload.php"
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         bootstrap="./vendor/autoload.php"
          colors="true"
          testdox="true"
-         convertErrorsToExceptions="true"
-         convertNoticesToExceptions="true"
-         convertWarningsToExceptions="true"
-         convertDeprecationsToExceptions="true"
-         stopOnFailure="false">
+         displayDetailsOnTestsThatTriggerDeprecations="true"
+         displayDetailsOnTestsThatTriggerErrors="true"
+         displayDetailsOnTestsThatTriggerNotices="true"
+         displayDetailsOnTestsThatTriggerWarnings="true"
+         displayDetailsOnPhpunitDeprecations="true"
+         failOnWarning="true"
+         failOnNotice="true"
+         failOnDeprecation="true"
+         failOnPhpunitDeprecation="true"
+         stopOnFailure="false"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd">
 
     <php>
         <ini name="display_errors" value="On" />
@@ -21,11 +28,11 @@ and open the template in the editor.
         <ini name="error_reporting" value="E_ALL" />
     </php>
 
-    <filter>
-        <whitelist>
+    <source>
+        <include>
             <directory>./src</directory>
-        </whitelist>
-    </filter>
+        </include>
+    </source>
 
     <testsuites>
         <testsuite name="Test Suite">

--- a/psalm.xml
+++ b/psalm.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0"?>
+<psalm
+    errorLevel="4"
+    resolveFromConfigFile="true"
+    findUnusedBaselineEntry="true"
+    findUnusedCode="false"
+    cacheDirectory="/tmp/psalm"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns="https://getpsalm.org/schema/config"
+    xsi:schemaLocation="https://getpsalm.org/schema/config vendor/vimeo/psalm/config.xsd">
+
+    <projectFiles>
+        <directory name="src"/>
+        <ignoreFiles>
+            <directory name="vendor"/>
+        </ignoreFiles>
+    </projectFiles>
+</psalm>

--- a/src/JwtSession.php
+++ b/src/JwtSession.php
@@ -2,8 +2,8 @@
 
 namespace ByJG\Session;
 
-use ByJG\Util\JwtWrapper;
-use ByJG\Util\JwtWrapperException;
+use ByJG\JwtWrapper\JwtWrapper;
+use ByJG\JwtWrapper\JwtWrapperException;
 use Exception;
 use SessionHandlerInterface;
 
@@ -64,6 +64,7 @@ class JwtSession implements SessionHandlerInterface
      * </p>
      * @since 5.4.0
      */
+    #[\Override]
     public function close(): bool
     {
         return true;
@@ -80,6 +81,7 @@ class JwtSession implements SessionHandlerInterface
      * </p>
      * @since 5.4.0
      */
+    #[\Override]
     public function destroy(string $id): bool
     {
         if (!headers_sent()) {
@@ -87,7 +89,7 @@ class JwtSession implements SessionHandlerInterface
                 self::COOKIE_PREFIX . $this->sessionConfig->getSessionContext(),
                 "",
                 (time()-3000),
-                $this->sessionConfig->getCookiePath() ?? "",
+                $this->sessionConfig->getCookiePath(),
                 $this->sessionConfig->getCookieDomain() ?? "",
             );
         }
@@ -99,19 +101,20 @@ class JwtSession implements SessionHandlerInterface
      * Cleanup old sessions
      *
      * @link http://php.net/manual/en/sessionhandlerinterface.gc.php
+     *
      * @param int $max_lifetime <p>
      * Sessions that have not updated for
      * the last maxlifetime seconds will be removed.
      * </p>
-     * @return int|false <p>
-     * The return value (usually TRUE on success, FALSE on failure).
-     * Note this value is returned internally to PHP for processing.
-     * </p>
+     *
+     * @return int|false <p> The return value (usually TRUE on success, FALSE on failure). Note this value is returned internally to PHP for processing. </p>
+     *
      * @since 5.4.0
      */
+    #[\Override]
     public function gc(int $max_lifetime): int|false
     {
-        return true;
+        return 1;
     }
 
     /**
@@ -126,6 +129,7 @@ class JwtSession implements SessionHandlerInterface
      * </p>
      * @since 5.4.0
      */
+    #[\Override]
     public function open(string $path, string $name): bool
     {
         return true;
@@ -143,6 +147,7 @@ class JwtSession implements SessionHandlerInterface
      * </p>
      * @since 5.4.0
      */
+    #[\Override]
     public function read(string $id): string
     {
         try {
@@ -184,13 +189,14 @@ class JwtSession implements SessionHandlerInterface
      * @throws JwtWrapperException
      * @since 5.4.0
      */
+    #[\Override]
     public function write(string $id, string $data): bool
     {
         $jwt = new JwtWrapper(
             $this->sessionConfig->getServerName(),
             $this->sessionConfig->getKey()
         );
-        $session_data = $jwt->createJwtData($data, $this->sessionConfig->getTimeoutMinutes() * 60);
+        $session_data = $jwt->createJwtData(['data' => $data], $this->sessionConfig->getTimeoutMinutes() * 60, 0, null);
         $token = $jwt->generateToken($session_data);
 
         if (!headers_sent()) {
@@ -198,7 +204,7 @@ class JwtSession implements SessionHandlerInterface
                 self::COOKIE_PREFIX . $this->sessionConfig->getSessionContext(),
                 $token,
                 (time()+$this->sessionConfig->getTimeoutMinutes()*60) ,
-                $this->sessionConfig->getCookiePath() ?? "",
+                $this->sessionConfig->getCookiePath(),
                 $this->sessionConfig->getCookieDomain() ?? "",
                 false,
                 true
@@ -236,7 +242,7 @@ class JwtSession implements SessionHandlerInterface
             $num = $pos - $offset;
             $varname = substr($session_data, $offset, $num);
             $offset += $num + 1;
-            $data = unserialize(substr($session_data, $offset));
+            $data = @unserialize(substr($session_data, $offset), ['allowed_classes' => true]);
             $return_data[$varname] = $data;
             $offset += strlen(serialize($data));
         }

--- a/src/SessionConfig.php
+++ b/src/SessionConfig.php
@@ -2,9 +2,9 @@
 
 namespace ByJG\Session;
 
-use ByJG\Util\JwtKeyInterface;
-use ByJG\Util\JwtKeySecret;
-use ByJG\Util\JwtRsaKey;
+use ByJG\JwtWrapper\JwtKeyInterface;
+use ByJG\JwtWrapper\JwtHashHmacSecret;
+use ByJG\JwtWrapper\JwtOpenSSLKey;
 
 class SessionConfig
 {
@@ -53,13 +53,13 @@ class SessionConfig
 
     public function withSecret($secret): static
     {
-        $this->jwtKey = new JwtKeySecret($secret);
+        $this->jwtKey = new JwtHashHmacSecret($secret);
         return $this;
     }
-    
+
     public function withRsaSecret($private, $public): static
     {
-        $this->jwtKey = new JwtRsaKey($private, $public);
+        $this->jwtKey = new JwtOpenSSLKey($private, $public);
         return $this;
     }
 

--- a/tests/JwtSessionTest.php
+++ b/tests/JwtSessionTest.php
@@ -1,10 +1,11 @@
 <?php
 
+use ByJG\JwtWrapper\JwtWrapperException;
 use ByJG\Session\JwtSession;
 use ByJG\Session\JwtSessionException;
 use ByJG\Session\SessionConfig;
-use ByJG\Util\JwtWrapperException;
 use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 ob_start();
 define("SETCOOKIE_FORTEST", "TESTCASE");
@@ -57,7 +58,7 @@ class JwtSessionTest extends TestCase
         $this->assertTrue($this->object->close());
     }
 
-    public function dataProvider(): array
+    public static function dataProvider(): array
     {
         $obj = new stdClass();
         $obj->prop1 = "value1";
@@ -119,35 +120,21 @@ class JwtSessionTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider dataProvider
-     * @param $input
-     * @param $expected
-     */
+    #[DataProvider('dataProvider')]
     public function testSerializeSessionData($input, $expected)
     {
         $result = $this->object->serializeSessionData($input);
         $this->assertEquals($expected, $result);
     }
 
-    /**
-     * @dataProvider dataProvider
-     * @param $expected
-     * @param $input
-     * @throws Exception
-     */
+    #[DataProvider('dataProvider')]
     public function testUnserializeData($expected, $input)
     {
         $result = $this->object->unSerializeSessionData($input);
         $this->assertEquals($expected, $result);
     }
 
-    /**
-     * @dataProvider dataProvider
-     * @param $object
-     * @param $serialize
-     * @throws JwtWrapperException
-     */
+    #[DataProvider('dataProvider')]
     public function testReadWrite($object, $serialize)
     {
         $this->object->write("SESSID", $serialize);


### PR DESCRIPTION
# JWT Session 6.0 - Major Version Update

## Overview

This PR introduces version 6.0 of the JWT Session library with significant updates to improve code quality, modernize dependencies, and align with current PHP best practices.

## Major Changes

### Dependency Updates
- **JWT Wrapper**: Upgraded from `4.9.*` to `^6.0` with updated namespaces
- **PHPUnit**: Upgraded from `5.7.*|7.4.*|^9.6` to `^10|^11`
- **Psalm**: Added static analysis tool (`^5.9|^6.12`)

### PHP Version Support
- Minimum PHP version increased from `8.0` to `8.1`
- Maximum PHP version capped at `8.5`
- GitHub Actions CI now tests against PHP 8.4, 8.3, 8.2, and 8.1

### Code Quality Improvements
- Added Psalm static analysis configuration
- Updated PHPUnit configuration to modern XML schema (10.5)
- Added `#[\Override]` attributes to all interface method implementations
- Improved error handling with stricter deprecation/warning/notice failures in tests
- Added composer scripts for `test` and `psalm`

### Testing Infrastructure
- Migrated from PHPUnit docblock annotations to PHP 8.1+ attributes (`#[DataProvider]`)
- Enhanced GitHub Actions workflow with container options and updated checkout action to v5
- Updated documentation workflow with explicit secret handling

## Breaking Changes

| Category | Change | Impact |
|----------|--------|--------|
| **PHP Version** | Minimum version: `8.0` → `8.1` | Projects using PHP 8.0 must upgrade to PHP 8.1+ |
| **PHP Version** | Added maximum version constraint: `<8.5` | Prevents usage with PHP 8.5+ until explicitly supported |
| **Dependency** | `byjg/jwt-wrapper`: `4.9.*` → `^6.0` | Major version upgrade - see jwt-wrapper 6.0 changelog |
| **Namespace** | `ByJG\Util\JwtWrapper` → `ByJG\JwtWrapper\JwtWrapper` | Update all imports |
| **Namespace** | `ByJG\Util\JwtWrapperException` → `ByJG\JwtWrapper\JwtWrapperException` | Update all exception handling imports |
| **Namespace** | `ByJG\Util\JwtKeyInterface` → `ByJG\JwtWrapper\JwtKeyInterface` | Update all type hints |
| **Class Rename** | `JwtKeySecret` → `JwtHashHmacSecret` | Update all instantiations of secret-based JWT keys |
| **Class Rename** | `JwtRsaKey` → `JwtOpenSSLKey` | Update all instantiations of RSA-based JWT keys |
| **Method Signature** | `JwtWrapper::createJwtData()` parameter changes | Data now wrapped in array: `['data' => $data]` |
| **Method Return Type** | `gc()`: `bool` → `int\|false` | Return value changed from `true` to `1` |
| **Dev Dependency** | PHPUnit: `5.7.*\|7.4.*\|^9.6` → `^10\|^11` | Development environments must update PHPUnit |
| **Test Annotations** | Docblock `@dataProvider` → Attribute `#[DataProvider]` | Custom test extensions may need updates |

## Migration Guide

### For Library Users

1. **Update composer.json**:
   ```json
   {
     "require": {
       "php": ">=8.1",
       "byjg/jwt-session": "^6.0"
     }
   }
   ```

2. **Update namespace imports**:
   ```php
   // Before
   use ByJG\Util\JwtWrapper;
   use ByJG\Util\JwtWrapperException;
   use ByJG\Util\JwtKeySecret;
   use ByJG\Util\JwtRsaKey;

   // After
   use ByJG\JwtWrapper\JwtWrapper;
   use ByJG\JwtWrapper\JwtWrapperException;
   use ByJG\JwtWrapper\JwtHashHmacSecret;
   use ByJG\JwtWrapper\JwtOpenSSLKey;
   ```

3. **Update SessionConfig usage**:
   ```php
   // Before
   use ByJG\Util\JwtKeySecret;

   // After
   use ByJG\JwtWrapper\JwtHashHmacSecret;

   // For RSA keys
   // Before: new JwtRsaKey($private, $public)
   // After: new JwtOpenSSLKey($private, $public)
   ```

### For Contributors

1. Ensure PHP 8.1+ is installed
2. Run `composer install` to get PHPUnit 10/11
3. Use new test commands:
   - `composer test` or `./vendor/bin/phpunit`
   - `composer psalm` or `./vendor/bin/psalm`

## Files Changed

- `.github/workflows/phpunit.yml` - Updated CI/CD pipeline
- `.gitignore` - Added coverage and report files
- `composer.json` - Updated dependencies and added scripts
- `phpunit.xml.dist` - Modernized configuration
- `psalm.xml` - New static analysis configuration
- `src/JwtSession.php` - Updated namespaces and added Override attributes
- `src/SessionConfig.php` - Updated class names
- `tests/JwtSessionTest.php` - Migrated to modern PHPUnit attributes

## Testing

All tests pass with:
- PHP 8.4
- PHP 8.3
- PHP 8.2
- PHP 8.1

Static analysis (Psalm level 4) passes with no errors.
